### PR TITLE
display-events

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,7 +1,8 @@
-import React, { useReducer, useState } from 'react';
-import 'bootstrap/dist/css/bootstrap.min.css';
+import React, { useReducer, useState } from 'react'
+import 'bootstrap/dist/css/bootstrap.min.css'
 
-import reducer from '../reducers/index.js';
+import Event from './Event'
+import reducer from '../reducers'
 
 const App = () => {
   const [state, dispatch] = useReducer(reducer, [])
@@ -53,22 +54,7 @@ const App = () => {
           </tr>
         </thead>
         <tbody>
-          {
-            state.map((event, index) => {
-              const id = event.id
-              const handleClickDeleteButton = () => {}
-                dispatch({ type: 'DELETE_EVENT', id })
-
-              return (
-                <tr key={index}>
-                  <td>{id}</td>
-                  <td>{event.title}</td>
-                  <td>{event.body}</td>
-                  <td><button type="button" className="btn btn-danger" onClick={handleClickDeleteButton}>削除</button></td>
-                </tr>
-              )
-            })
-          }
+          { state.map((event, index) => (<Event key ={index} event={event} dispatch={dispatch} />))}
         </tbody>
       </table>
     </div>

--- a/src/components/Event.js
+++ b/src/components/Event.js
@@ -1,0 +1,17 @@
+import React from 'react';
+
+const Event = ({ dispatch, event}) => {
+  const id = event.id
+  const handleClickDeleteButton = () => {
+    dispatch({ type: 'DELETE_EVENT', id })
+  }
+  return (
+    <tr>
+      <td>{id}</td>
+      <td>{event.title}</td>
+      <td>{event.body}</td>
+      <td><button type="button" className="btn btn-danger" onClick={handleClickDeleteButton}>削除</button></td>
+    </tr>
+  )
+}
+export default Event

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -28,7 +28,7 @@ const events = (state = [], action) => {
     case 'CREATE_EVENT':
       const event = { title: action.title, body: action.body }
       const length = state.length
-      const id = length === 0 ? 1 : id = state[length - 1].id + 1
+      const id = length === 0 ? 1 : state[length - 1].id + 1
       return [...state, { id, ...event }]
     case 'DELETE_EVENT':
       return state.filter(event => event.id !== action.id)


### PR DESCRIPTION
# What
Eventコンポーネントを作成し、Appコンポーネントでimportを行う。
Appコンポーネント内でstate.mapでイベントの数だけ描画させるように繰り返し処理を行っている。

Eventコンポーネント内はeventのレンダリング、eventハンドラーで削除ボタンの実装。
dispatch({ type: 'DELETE_EVENT', id })の通り、dispatchでidを渡し、どのイベントが削除されたのかを判断させる。reducer側でreturn state.filter(event => event.id !== action.id)の通り、アクションで渡ってくるidを消して、残りのidのものを残すfilterをかけるように状態管理する。