### PR TITLE
refactor events with reducer

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -8,7 +8,10 @@ import reducer from '../reducers'
 
 
 const App = () => {
-  const [state, dispatch] = useReducer(reducer, [])
+  const initialState = {
+    events: []
+  }
+  const [state, dispatch] = useReducer(reducer, initialState)
 
   return (
     <AppContext.Provider value={{ state, dispatch }}>

--- a/src/components/EventForm.js
+++ b/src/components/EventForm.js
@@ -47,7 +47,7 @@ const EventForm = () => {
           setBody(e.target.value)}/>
         </div>
         <button className="btn btn-primary" onClick={addEvent} disabled={unCreatable}>イベントを作成する</button>
-        <button className="btn btn-danger" onClick={deleteAllEvents} disabled={state.length === 0}>全てのイベントを削除する</button>
+        <button className="btn btn-danger" onClick={deleteAllEvents} disabled={state.events.length === 0}>全てのイベントを削除する</button>
       </form>
     </>
   )

--- a/src/components/Events.js
+++ b/src/components/Events.js
@@ -18,7 +18,7 @@ const Events = () => {
           </tr>
         </thead>
         <tbody>
-          { state.map((event, index) => (<Event key ={index} event={event} />))}
+          { state.events.map((event, index) => (<Event key ={index} event={event} />))}
         </tbody>
       </table>
     </>

--- a/src/reducers/events.js
+++ b/src/reducers/events.js
@@ -1,0 +1,47 @@
+import {
+  CREATE_EVENT,
+  DELETE_ALL_EVENTS,
+  DELETE_EVENT
+} from '../actions'
+// action = {
+//   type: 'CREATE_EVENT',
+//   title: '2020東京オリンピックのお知らせ',
+//   body: '2020年に東京でオリンピックを開催します！つきましては、、、、、'
+// }
+
+// before
+// state = []
+// after
+// state = [
+//   {
+//     id: 1,
+//     title: '2020東京オリンピックのお知らせ',
+//     body: '2020年に東京でオリンピックを開催します！つきましては、、、、、'
+    
+//   }
+// ]
+
+// state = []
+// state = [
+//   { id: 1, title: 'タイトル１', body: 'ボディー１'},
+//   { id: 1, title: 'タイトル１', body: 'ボディー１'},
+//   { id: 1, title: 'タイトル１', body: 'ボディー１'},
+// ]
+
+const events = (state = [], action) => {
+  switch(action.type) {
+    case CREATE_EVENT:
+      const event = { title: action.title, body: action.body }
+      const length = state.length
+      const id = length === 0 ? 1 : state[length - 1].id + 1
+      return [...state, { id, ...event }]
+    case DELETE_EVENT:
+      return state.filter(event => event.id !== action.id)
+    case DELETE_ALL_EVENTS:
+      return []
+    default:
+      return state
+  }
+}
+
+export default events

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,47 +1,6 @@
-import {
-  CREATE_EVENT,
-  DELETE_ALL_EVENTS,
-  DELETE_EVENT
-} from '../actions'
-// action = {
-//   type: 'CREATE_EVENT',
-//   title: '2020東京オリンピックのお知らせ',
-//   body: '2020年に東京でオリンピックを開催します！つきましては、、、、、'
-// }
+import { combineReducers } from 'redux'
 
-// before
-// state = []
-// after
-// state = [
-//   {
-//     id: 1,
-//     title: '2020東京オリンピックのお知らせ',
-//     body: '2020年に東京でオリンピックを開催します！つきましては、、、、、'
-    
-//   }
-// ]
+import events from './events'
 
-// state = []
-// state = [
-//   { id: 1, title: 'タイトル１', body: 'ボディー１'},
-//   { id: 1, title: 'タイトル１', body: 'ボディー１'},
-//   { id: 1, title: 'タイトル１', body: 'ボディー１'},
-// ]
+export default combineReducers({ events })
 
-const events = (state = [], action) => {
-  switch(action.type) {
-    case CREATE_EVENT:
-      const event = { title: action.title, body: action.body }
-      const length = state.length
-      const id = length === 0 ? 1 : state[length - 1].id + 1
-      return [...state, { id, ...event }]
-    case DELETE_EVENT:
-      return state.filter(event => event.id !== action.id)
-    case DELETE_ALL_EVENTS:
-      return []
-    default:
-      return state
-  }
-}
-
-export default events


### PR DESCRIPTION
# What
useReducerで初期化する際に、正しい初期化の構造はオブジェクトであるため、
const initialState = {
    events: []
  }
const [state, dispatch] = useReducer(reducer, initialState)
として、events の初期値を配列[]にしている。

今までstateは配列だったが、現在はオブジェクトとなっているため、
<button className="btn btn-danger" onClick={deleteAllEvents} disabled={state.length === 0}>全てのイベントを削除する</button>
の記述を以下に変更
<button className="btn btn-danger" onClick={deleteAllEvents} disabled={state.events.length === 0}>全てのイベントを削除する</button>

同様に、
 { state.map((event, index) => (<Event key ={index} event={event} />))}
の記述も、
{ state.events.map((event, index) => (<Event key ={index} event={event} />))}
として、stateのeventsの配列に対してmapメソッドを使用するように記述する。
